### PR TITLE
add template for wb mwac v2

### DIFF
--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -97,17 +97,17 @@
   {
     "manufacturer": "Wiren Board",
     "model": "WB-MWAC v.2",
-    "name": "Датчик протечки",
+    "name": "Дискретный вход",
     "services": [
       {
-        "name": "Датчик протечки",
-        "type": "LeakSensor",
+        "name": "Состояние входа",
+        "type": "ContactSensor",
         "characteristics": [
           {
-            "type": "LeakDetected",
+            "type": "ContactSensorState",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input F[0-9])/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9]) Single Press Counter/meta/type",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }
@@ -188,24 +188,24 @@
   {
     "manufacturer": "Wiren Board",
     "model": "WB-MWAC v.2",
-    "name": "Дискретный вход",
+    "name": "Датчик протечки",
     "services": [
       {
-        "name": "Состояние входа",
-        "type": "ContactSensor",
+        "name": "Датчик протечки",
+        "type": "LeakSensor",
         "characteristics": [
           {
-            "type": "ContactSensorState",
+            "type": "LeakDetected",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input S[0-9])/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9])/meta/type",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }
         ]
       },
       {
-        "name": "Счётчик срабатываний входа",
+        "name": "Счётчик срабатываний датчика",
         "visible": false,
         "type": "C_PulseMeter",
         "characteristics": [
@@ -214,62 +214,6 @@
             "link": {
               "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Counter"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Счетчик коротких нажатий",
-        "visible": false,
-        "type": "C_PulseMeter",
-        "characteristics": [
-          {
-            "type": "C_PulseCount",
-            "link": {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Счетчик длинных нажатий",
-        "visible": false,
-        "type": "C_PulseMeter",
-        "characteristics": [
-          {
-            "type": "C_PulseCount",
-            "link": {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Счетчик двойных нажатий",
-        "visible": false,
-        "type": "C_PulseMeter",
-        "characteristics": [
-          {
-            "type": "C_PulseCount",
-            "link": {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Счетчик коротких, а затем длинных нажатий",
-        "visible": false,
-        "type": "C_PulseMeter",
-        "characteristics": [
-          {
-            "type": "C_PulseCount",
-            "link": {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
             }
           }
         ]

--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -1,0 +1,279 @@
+[
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Защита от протечки",
+    "catalogId": 4983,
+    "services": [
+      {
+        "name": "Кран 1",
+        "type": "Valve",
+        "characteristics": [
+          {
+            "type": "Active",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/Output K1/meta/type",
+              "topicGet": "/devices/(1)/controls/Output K1",
+              "topicSet": "/devices/(1)/controls/Output K1/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Кран 2",
+        "type": "Valve",
+        "characteristics": [
+          {
+            "type": "Active",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Output K2",
+              "topicSet": "/devices/(1)/controls/Output K2/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Режим: протечка",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Leakage Mode",
+              "topicSet": "/devices/(1)/controls/Leakage Mode/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Режим: влажная уборка",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Cleaning Mode",
+              "topicSet": "/devices/(1)/controls/Cleaning Mode/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик 1",
+        "visible": false,
+        "type": "C_WaterMeter",
+        "characteristics": [
+          {
+            "type": "C_CubicMeter",
+            "link": {
+              "type": "float",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P1 Volume/meta/type",
+              "topicGet": "/devices/(1)/controls/P1 Volume"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик 2",
+        "visible": false,
+        "type": "C_WaterMeter",
+        "characteristics": [
+          {
+            "type": "C_CubicMeter",
+            "link": {
+              "type": "float",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P2 Volume/meta/type",
+              "topicGet": "/devices/(1)/controls/P2 Volume"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Датчик протечки",
+    "services": [
+      {
+        "name": "Датчик протечки",
+        "type": "LeakSensor",
+        "characteristics": [
+          {
+            "type": "LeakDetected",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input F[0-9])/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик срабатываний датчика",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик двойных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких, а затем длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Дискретный вход",
+    "services": [
+      {
+        "name": "Состояние входа",
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input S[0-9])/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик срабатываний входа",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик двойных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких, а затем длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Добавлен шаблон для WB-MWAC v2.
Шаблон определяет тип входа.
Или датчик протечки:
![2024-04-01_10-39](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/edc5a111-f323-4530-8cc1-9f4b389f823b)
Или дискретный вход:
![2024-04-01_10-40](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/2af56741-2f5e-4d57-bb0d-b31746682b36)
