### PR TITLE
add temlate file for wb-mwac-v2

### DIFF
--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -71,7 +71,6 @@
             "type": "C_CubicMeter",
             "link": {
               "type": "float",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P1 Volume/meta",
               "topicGet": "/devices/(1)/controls/P1 Volume"
             }
           }
@@ -86,7 +85,6 @@
             "type": "C_CubicMeter",
             "link": {
               "type": "float",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P2 Volume/meta",
               "topicGet": "/devices/(1)/controls/P2 Volume"
             }
           }

--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -112,7 +112,7 @@
         ]
       },
       {
-        "name": "Счётчик срабатываний датчика",
+        "name": "Счётчик срабатываний входа",
         "visible": false,
         "type": "C_PulseMeter",
         "characteristics": [

--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -13,7 +13,7 @@
             "type": "Active",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/Output K1/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/Output K1/meta",
               "topicGet": "/devices/(1)/controls/Output K1",
               "topicSet": "/devices/(1)/controls/Output K1/on"
             }
@@ -71,7 +71,7 @@
             "type": "C_CubicMeter",
             "link": {
               "type": "float",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P1 Volume/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P1 Volume/meta",
               "topicGet": "/devices/(1)/controls/P1 Volume"
             }
           }
@@ -86,7 +86,7 @@
             "type": "C_CubicMeter",
             "link": {
               "type": "float",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P2 Volume/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P2 Volume/meta",
               "topicGet": "/devices/(1)/controls/P2 Volume"
             }
           }
@@ -107,7 +107,7 @@
             "type": "ContactSensorState",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9]) Single Press Counter/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9]) Single Press Counter/meta",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }
@@ -198,7 +198,7 @@
             "type": "LeakDetected",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9])/meta/type",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9])/meta",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }

--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -1,0 +1,223 @@
+[
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Защита от протечки",
+    "catalogId": 4983,
+    "services": [
+      {
+        "name": "Кран 1",
+        "type": "Valve",
+        "characteristics": [
+          {
+            "type": "Active",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/Output K1/meta/type",
+              "topicGet": "/devices/(1)/controls/Output K1",
+              "topicSet": "/devices/(1)/controls/Output K1/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Кран 2",
+        "type": "Valve",
+        "characteristics": [
+          {
+            "type": "Active",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Output K2",
+              "topicSet": "/devices/(1)/controls/Output K2/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Режим: протечка",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Leakage Mode",
+              "topicSet": "/devices/(1)/controls/Leakage Mode/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Режим: влажная уборка",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Cleaning Mode",
+              "topicSet": "/devices/(1)/controls/Cleaning Mode/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик 1",
+        "visible": false,
+        "type": "C_WaterMeter",
+        "characteristics": [
+          {
+            "type": "C_CubicMeter",
+            "link": {
+              "type": "float",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P1 Volume/meta/type",
+              "topicGet": "/devices/(1)/controls/P1 Volume"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик 2",
+        "visible": false,
+        "type": "C_WaterMeter",
+        "characteristics": [
+          {
+            "type": "C_CubicMeter",
+            "link": {
+              "type": "float",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/P2 Volume/meta/type",
+              "topicGet": "/devices/(1)/controls/P2 Volume"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Дискретный вход",
+    "services": [
+      {
+        "name": "Состояние входа",
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9]) Single Press Counter/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик срабатываний датчика",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик двойных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счетчик коротких, а затем длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MWAC v.2",
+    "name": "Датчик протечки",
+    "services": [
+      {
+        "name": "Датчик протечки",
+        "type": "LeakSensor",
+        "characteristics": [
+          {
+            "type": "LeakDetected",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mwac-v2_[0-9]{1,3})/controls/(Input [a-zA-Z][0-9])/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Счётчик срабатываний датчика",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) Counter"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Добавлен шаблон для WB-MWAC v2.
Шаблон определяет тип входа.
Или датчик протечки:
![2024-04-01_10-39](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/69738f38-dc18-4a19-9394-1defc6519447)

Или дискретный вход:
![2024-04-01_10-40](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/6bd69ada-e275-473b-96eb-76611e45de0b)

А также основной сервис "Защита от протечки":
![2024-04-01_10-47](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/0de24bf7-fefa-4c7e-b410-39bcfe9d959e)

