### PR TITLE
add curtain mode for wb mrm2 mini

### DIFF
--- a/mqtt/WB-MRM2-mini.json
+++ b/mqtt/WB-MRM2-mini.json
@@ -50,7 +50,7 @@
             "type": "On",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mrm2-mini_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+              "topicSearch": "/devices/(wb-mrm2-mini_[0-9]{1,3})/controls/K([0-9]{1,2})/meta",
               "topicGet": "/devices/(1)/controls/K(2)",
               "topicSet": "/devices/(1)/controls/K(2)/on"
             }
@@ -142,5 +142,5 @@
         ]
       }
     ]
- }
+  }
 ]

--- a/mqtt/WB-MRM2-mini.json
+++ b/mqtt/WB-MRM2-mini.json
@@ -37,110 +37,110 @@
     ]
   },
   {
-  "manufacturer": "Wiren Board",
-  "model": "WB-MRM2-mini",
-  "name": "Канал реле и дискретный вход",
-  "catalogId": 378,
-  "services": [
-    {
-      "name": "Реле",
-      "type": "Switch",
-      "characteristics": [
-        {
-          "type": "On",
-          "link": {
-            "type": "Integer",
-            "topicSearch": "/devices/(wb-mrm2-mini_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
-            "topicGet": "/devices/(1)/controls/K(2)",
-            "topicSet": "/devices/(1)/controls/K(2)/on"
+    "manufacturer": "Wiren Board",
+    "model": "WB-MRM2-mini",
+    "name": "Канал реле и дискретный вход",
+    "catalogId": 378,
+    "services": [
+      {
+        "name": "Реле",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mrm2-mini_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+              "topicGet": "/devices/(1)/controls/K(2)",
+              "topicSet": "/devices/(1)/controls/K(2)/on"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Состояние входа",
-      "visible": false,
-      "type": "ContactSensor",
-      "characteristics": [
-        {
-          "type": "ContactSensorState",
-          "link": {
-            "type": "Integer",
-            "topicGet": "/devices/(1)/controls/Input (2)"
+        ]
+      },
+      {
+        "name": "Состояние входа",
+        "visible": false,
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Input (2)"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Счетчик",
-      "visible": false,
-      "type": "C_PulseMeter",
-      "characteristics": [
-        {
-          "type": "C_PulseCount",
-          "link": {
-            "type": "float",
-            "topicGet": "/devices/(1)/controls/Input (2) counter"
+        ]
+      },
+      {
+        "name": "Счетчик",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "float",
+              "topicGet": "/devices/(1)/controls/Input (2) counter"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Счетчик коротких нажатий",
-      "visible": false,
-      "type": "C_PulseMeter",
-      "characteristics": [
-        {
-          "type": "C_PulseCount",
-          "link": {
-            "type": "float",
-            "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
+        ]
+      },
+      {
+        "name": "Счетчик коротких нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "float",
+              "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Счетчик длинных нажатий",
-      "visible": false,
-      "type": "C_PulseMeter",
-      "characteristics": [
-        {
-          "type": "C_PulseCount",
-          "link": {
-            "type": "float",
-            "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
+        ]
+      },
+      {
+        "name": "Счетчик длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "float",
+              "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Счетчик двойных нажатий",
-      "visible": false,
-      "type": "C_PulseMeter",
-      "characteristics": [
-        {
-          "type": "C_PulseCount",
-          "link": {
-            "type": "float",
-            "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
+        ]
+      },
+      {
+        "name": "Счетчик двойных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "float",
+              "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
+            }
           }
-        }
-      ]
-    },
-    {
-      "name": "Счетчик коротких, а затем длинных нажатий",
-      "visible": false,
-      "type": "C_PulseMeter",
-      "characteristics": [
-        {
-          "type": "C_PulseCount",
-          "link": {
-            "type": "float",
-            "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
+        ]
+      },
+      {
+        "name": "Счетчик коротких, а затем длинных нажатий",
+        "visible": false,
+        "type": "C_PulseMeter",
+        "characteristics": [
+          {
+            "type": "C_PulseCount",
+            "link": {
+              "type": "float",
+              "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
+            }
           }
-        }
-      ]
-    }
-  ]
+        ]
+      }
+    ]
  }
 ]

--- a/mqtt/WB-MRM2-mini.json
+++ b/mqtt/WB-MRM2-mini.json
@@ -1,7 +1,46 @@
-{
+[
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MRM2-mini",
+    "name": "Штора",
+    "catalogId": 378,
+    "services": [
+      {
+        "name": "Открыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mrm2-mini_[0-9]{1,3})/controls/(Curtain [0-9]{1,2}) Open/meta",
+              "topicGet": "/devices/(1)/controls/(2) Open",
+              "topicSet": "/devices/(1)/controls/(2) Open/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Закрыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/(2) Close",
+              "topicSet": "/devices/(1)/controls/(2) Close/on"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
   "manufacturer": "Wiren Board",
   "model": "WB-MRM2-mini",
   "name": "Канал реле и дискретный вход",
+  "catalogId": 378,
   "services": [
     {
       "name": "Реле",
@@ -103,4 +142,5 @@
       ]
     }
   ]
-}
+ }
+]


### PR DESCRIPTION
Управление выглядит таким образом:
![2024-04-03_16-37](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/dc459e3a-dcc3-4975-9330-c7975bee1dc2)

К сожалению, если нажать, например, "Открыть", а потом не дожидаясь отработки реле нажать "Закрыть", то индикация состояния будет такой:
![2024-04-03_16-36](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/a3eb8656-1ed8-4664-a154-7ed27777594b)
