### PR TITLE
add-curtain-mode-for-wb-mr6cu

### DIFF
--- a/mqtt/WB-MR6CU.json
+++ b/mqtt/WB-MR6CU.json
@@ -1,24 +1,62 @@
-{
-  "name": "Реле",
-  "manufacturer": "Wiren Board",
-  "model": "MR6CU",
-  "services": [
-    {
-      "name": "Реле",
-      "type": "Switch",
-      "characteristics": [
-        {
-          "type": "On",
-          "link": {
-            "type": "Integer",
-            "topicSearch": "/devices/(wb-mr6cu_[0-9]{1,3})/controls/(K[0-9])/meta/type",
-            "topicGet": "/devices/(1)/controls/(2)",
-            "topicSet": "/devices/(1)/controls/(2)/on"
+[
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MR3",
+    "name": "Штора",
+    "catalogId": 3207,
+    "services": [
+      {
+        "name": "Открыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mr6cu_[0-9]{1,3})/controls/(Curtain [0-9]{1,2}) Open/meta",
+              "topicGet": "/devices/(1)/controls/(2) Open",
+              "topicSet": "/devices/(1)/controls/(2) Open/on"
+            }
           }
-        }
-      ]
-    }
-  ]
-}
-
-
+        ]
+      },
+      {
+        "name": "Закрыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/(2) Close",
+              "topicSet": "/devices/(1)/controls/(2) Close/on"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Канал реле",
+    "manufacturer": "Wiren Board",
+    "model": "MR6CU",
+    "catalogId": 3207,
+    "services": [
+      {
+        "name": "Реле",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mr6cu_[0-9]{1,3})/controls/(K[0-9])/meta",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "topicSet": "/devices/(1)/controls/(2)/on"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Добавлен режим управления шторами для WB-MR6CU

Как выглядит:
![2024-04-09_11-01](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/5c080419-66ed-4eed-b0c8-cb18e214a399)
