### PR TITLE
add-curtain-mode-for-wb-mr6cv3

### DIFF
--- a/mqtt/WB-MR6Cv3.json
+++ b/mqtt/WB-MR6Cv3.json
@@ -2,7 +2,45 @@
   {
     "manufacturer": "Wiren Board",
     "model": "WB-MR6C v.3",
+    "name": "Штора",
+    "catalogId": 3956,
+    "services": [
+      {
+        "name": "Открыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mr6cv3_[0-9]{1,3})/controls/(Curtain [0-9]{1,2}) Open/meta",
+              "topicGet": "/devices/(1)/controls/(2) Open",
+              "topicSet": "/devices/(1)/controls/(2) Open/on"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Закрыть",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/(2) Close",
+              "topicSet": "/devices/(1)/controls/(2) Close/on"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "Wiren Board",
+    "model": "WB-MR6C v.3",
     "name": "Канал реле и дискретный вход",
+    "catalogId": 3956,
     "services": [
       {
         "name": "Реле",
@@ -12,7 +50,7 @@
             "type": "On",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mr6cv3_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+              "topicSearch": "/devices/(wb-mr6cv3_[0-9]{1,3})/controls/K([0-9]{1,2})/meta",
               "topicGet": "/devices/(1)/controls/K(2)",
               "topicSet": "/devices/(1)/controls/K(2)/on"
             }
@@ -109,6 +147,7 @@
     "manufacturer": "Wiren Board",
     "model": "WB-MR6C v.3",
     "name": "Дискретный вход 0 и питание",
+    "catalogId": 3956,
     "services": [
       {
         "name": "Состояние входа",
@@ -119,7 +158,7 @@
             "type": "ContactSensorState",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mr6cv3_[0-9]{1,3})/controls/(Input 0)/meta/type",
+              "topicSearch": "/devices/(wb-mr6cv3_[0-9]{1,3})/controls/(Input 0)/meta",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }

--- a/mqtt/WB-MR6Cv3.json
+++ b/mqtt/WB-MR6Cv3.json
@@ -79,7 +79,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) counter"
             }
           }
@@ -93,7 +93,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
             }
           }
@@ -107,7 +107,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
             }
           }
@@ -121,7 +121,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
             }
           }
@@ -135,7 +135,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
             }
           }
@@ -172,7 +172,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) counter"
             }
           }
@@ -186,7 +186,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
             }
           }
@@ -200,7 +200,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
             }
           }
@@ -214,7 +214,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
             }
           }
@@ -228,7 +228,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input 0 Shortlong Press Counter"
             }
           }


### PR DESCRIPTION
Добавлен режим управления шторами для WB-MR6Cv3

Как выглядит:
![2024-04-09_11-14](https://github.com/wirenboard/wb-spruthub-templates/assets/141926144/c2c82e28-7a3e-4ada-b9a0-2299901b7003)
