### PR TITLE
fix-topic-meta-type-for-wb-mdm3

### DIFF
--- a/mqtt/WB-MDM3.json
+++ b/mqtt/WB-MDM3.json
@@ -12,7 +12,7 @@
             "type": "On",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mdm3_[0-9]{1,3})/controls/K([0-9])/meta/type",
+              "topicSearch": "/devices/(wb-mdm3_[0-9]{1,3})/controls/K([0-9])/meta",
               "topicGet": "/devices/(1)/controls/K(2)",
               "topicSet": "/devices/(1)/controls/K(2)/on"
             }
@@ -43,7 +43,7 @@
             "type": "ContactSensorState",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-mdm3_[0-9]{1,3})/controls/(Input [0-9]{1,2})/meta/type",
+              "topicSearch": "/devices/(wb-mdm3_[0-9]{1,3})/controls/(Input [0-9]{1,2})/meta",
               "topicGet": "/devices/(1)/controls/(2)"
             }
           }


### PR DESCRIPTION
Исправил топик в ключе поиска "topicSearch". Вместо  .../meta/type использовать .../meta.