### PR TITLE
add-template-for-wb-mai11

### DIFF
--- a/mqtt/WB-MAI11.json
+++ b/mqtt/WB-MAI11.json
@@ -1,0 +1,46 @@
+[
+  {
+    "manufacturer": "WirenBoard",
+    "model": "WB-MAI11",
+    "catalogId": 3933,
+    "services": [
+      {
+        "name": "Температура",
+        "type": "TemperatureSensor",
+        "characteristics": [
+          {
+            "type": "CurrentTemperature",
+            "link": {
+              "type": "Double",
+              "topicSearch": "/devices/(wb-mai11_[0-9]{1,3})/controls/(IN [0-9]{1,2}.?[PN]* Temperature)/meta",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "minStep": 0.1,
+              "checkValue": true
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "WB-MAI11",
+    "catalogId": 3933,
+    "services": [
+      {
+        "name": "Сухой контакт",
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-mai11_[0-9]{1,3})/controls/(IN [0-9]{1,2}.?[PN]* State)/meta",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Добавить шаблон для WB-MAI11. Создает только характеристику температуры или "сухого контакта".