### PR TITLE
add-new-templates-from-spruthub-beta-1-10-2-12979

### DIFF
--- a/mqtt/1-wire.json
+++ b/mqtt/1-wire.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "1-wire",
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicSearch": "/devices/(wb-w[0-9]{1,3})/controls/([0-9]{1,2}-[A-Za-z0-9]{1,12})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/Buzzer.json
+++ b/mqtt/Buzzer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Сирена",
+  "manufacturer": "WirenBoard",
+  "model": "System",
+  "services": [
+    {
+      "name": "Сирена",
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(buzzer)/controls/enabled/meta/type",
+            "topicGet": "/devices/(1)/controls/enabled",
+            "topicSet": "/devices/(1)/controls/enabled/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/Hwmon.json
+++ b/mqtt/Hwmon.json
@@ -1,0 +1,37 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "System",
+  "services": [
+    {
+      "name": "Плата",
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicSearch": "/devices/(hwmon)/controls/Board Temperature/meta/type",
+            "topicGet": "/devices/(1)/controls/Board Temperature",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "Процессор",
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/CPU Temperature",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/Power_status.json
+++ b/mqtt/Power_status.json
@@ -1,0 +1,21 @@
+{
+  "name": "Аккумулятор",
+  "manufacturer": "WirenBoard",
+  "model": "System",
+  "services": [
+    {
+      "name": "Аккумулятор",
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(power_status)/controls/working on battery/meta/type",
+            "topicGet": "/devices/(1)/controls/working on battery"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/System.json
+++ b/mqtt/System.json
@@ -1,0 +1,26 @@
+{
+  "name": "Перезагрузка WirenBoard",
+  "manufacturer": "WirenBoard",
+  "model": "System",
+  "visible": false,
+  "services": [
+    {
+      "name": "Перезагрузка WirenBoard",
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(system)/controls/Reboot/meta/type",
+            "topicGet": "/devices/(1)/controls/Reboot",
+            "topicSet": "/devices/(1)/controls/Reboot/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MDM2.json
+++ b/mqtt/WB-MDM2.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MDM2",
+  "services": [
+    {
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mdm2_[0-9]{1,3})/controls/Channel ([0-9])/meta/type",
+            "topicGet": "/devices/(1)/controls/Channel (2)",
+            "topicSet": "/devices/(1)/controls/Channel (2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MIO-GPIO-DIR.json
+++ b/mqtt/WB-MIO-GPIO-DIR.json
@@ -1,0 +1,32 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DO-R10R-4",
+  "services": [
+    {
+      "type": "WindowCovering",
+      "logics": [
+        {
+          "type": "TimerBasedPositionState",
+          "options": {
+            "WarmingUpTime": "1000",
+            "MovingTime": "15000"
+          }
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "C_TargetPositionState",
+          "link": {
+            "type": "Integer",
+            "format": "WBCovering",
+            "events": false,
+            "write": true,
+            "topicSearch": "/devices/(wb-mio-gpio_[0-9]{1,3}:[0-9]{1,3})/controls/DIR([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/DIR(2)",
+            "topicSet": "/devices/(1)/controls/DIR(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MIO-GPIO-DR.json
+++ b/mqtt/WB-MIO-GPIO-DR.json
@@ -1,0 +1,19 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MIO-GPIO-DR",
+  "services": [
+    {
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mio-gpio_[0-9]{1,3}:[0-9]{1,3})/controls/DR([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/DR(2)"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MIO-GPIO-HS.json
+++ b/mqtt/WB-MIO-GPIO-HS.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MIO-GPIO-HS",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mio-gpio_[0-9]{1,3}:[0-9]{1,3})/controls/HS([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/HS(2)",
+            "topicSet": "/devices/(1)/controls/HS(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/mqtt/WB-MIO-GPIO-IN.json
+++ b/mqtt/WB-MIO-GPIO-IN.json
@@ -1,0 +1,19 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MIO-GPIO-IN",
+  "services": [
+    {
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mio-gpio_[0-9]{1,3}:[0-9]{1,3})/controls/IN([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/IN(2)"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MIO-GPIO-K.json
+++ b/mqtt/WB-MIO-GPIO-K.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MIO-GPIO-K",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mio-gpio_[0-9]{1,3}:[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/K(2)",
+            "topicSet": "/devices/(1)/controls/K(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MR3LV.json
+++ b/mqtt/WB-MR3LV.json
@@ -1,0 +1,24 @@
+{
+  "name": "Выключатель",
+  "manufacturer": "Wirenboard",
+  "model": "MR3LV",
+  "services": [
+    {
+      "name": "Выключатель",
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mr3lv_[0-9]{1,3})/controls/(K[0-9])/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}
+
+

--- a/mqtt/WB-MR6C.json
+++ b/mqtt/WB-MR6C.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MR6C",
+  "catalogId": 375,
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mr6c_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/K(2)",
+            "topicSet": "/devices/(1)/controls/K(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MR6LV.json
+++ b/mqtt/WB-MR6LV.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MR6",
+  "catalogId": 374,
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mr6lv_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/K(2)",
+            "topicSet": "/devices/(1)/controls/K(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRGB-D.json
+++ b/mqtt/WB-MRGB-D.json
@@ -1,0 +1,29 @@
+{
+  "name": "Цветная лента",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MRGB-D",
+  "services": [
+    {
+      "name": "Цветная лента",
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness"
+        },
+        {
+          "type": "Hue",
+          "link": {
+            "type": "RGB",
+            "format": "RGB",
+            "topicSearch": "/devices/(wb-mrgb-d_[0-9]{1,3})/controls/RGB/meta/type",
+            "topicGet": "/devices/(1)/controls/RGB",
+            "topicSet": "/devices/(1)/controls/RGB/on"
+          }
+        },
+        {
+          "type": "Saturation"
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRGB.json
+++ b/mqtt/WB-MRGB.json
@@ -1,0 +1,29 @@
+{
+  "name": "Цветная лента",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MRGB",
+  "services": [
+    {
+      "name": "Цветная лента",
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness"
+        },
+        {
+          "type": "Hue",
+          "link": {
+            "type": "RGB",
+            "format": "RGB",
+            "topicSearch": "/devices/(wb-mrgb_[0-9]{1,3})/controls/RGB/meta/type",
+            "topicGet": "/devices/(1)/controls/RGB",
+            "topicSet": "/devices/(1)/controls/RGB/on"
+          }
+        },
+        {
+          "type": "Saturation"
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRGBW-D.json
+++ b/mqtt/WB-MRGBW-D.json
@@ -1,0 +1,44 @@
+{
+  "name": "Цветная лента",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MRGBW-D",
+  "services": [
+    {
+      "name": "Цветная лента",
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness"
+        },
+        {
+          "type": "Hue",
+          "link": {
+            "type": "RGB",
+            "format": "RGB",
+            "topicSearch": "/devices/(wb-mrgbw-d_[0-9]{1,3})/controls/RGB/meta/type",
+            "topicGet": "/devices/(1)/controls/RGB",
+            "topicSet": "/devices/(1)/controls/RGB/on"
+          }
+        },
+        {
+          "type": "Saturation"
+        }
+      ]
+    },
+    {
+      "name": "Белый канал",
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/White",
+            "topicSet": "/devices/(1)/controls/White/on",
+            "maxValue": 255
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRM2.json
+++ b/mqtt/WB-MRM2.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MRM2",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mrm2_[0-9]{1,3})/controls/Relay ([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/Relay (2)",
+            "topicSet": "/devices/(1)/controls/Relay (2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRPS6S.json
+++ b/mqtt/WB-MRPS6S.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MRPS6/S",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mrps6_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/K(2)",
+            "topicSet": "/devices/(1)/controls/K(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MRWL3.json
+++ b/mqtt/WB-MRWL3.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WB-MR6C",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-mrwl3_[0-9]{1,3})/controls/K([0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/K(2)",
+            "topicSet": "/devices/(1)/controls/K(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MS.json
+++ b/mqtt/WB-MS.json
@@ -1,0 +1,81 @@
+{
+  "name": "Комбинированный датчик",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MS",
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicSearch": "/devices/(wb-ms-thls-v2_[0-9]{1,3})/controls/Temperature/meta/type",
+            "topicGet": "/devices/(1)/controls/Temperature",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "HumiditySensor",
+      "characteristics": [
+        {
+          "type": "CurrentRelativeHumidity",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Humidity",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "LightSensor",
+      "characteristics": [
+        {
+          "type": "CurrentAmbientLightLevel",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Illuminance",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "visible": false,
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/External Sensor 1",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "visible": false,
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/External Sensor 2",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/mqtt/WB-MSGR.json
+++ b/mqtt/WB-MSGR.json
@@ -1,0 +1,21 @@
+{
+  "name": "Газ",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MSGR",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-msgr_[0-9]{1,3})/controls/Relay/meta/type",
+            "topicGet": "/devices/(1)/controls/Relay",
+            "topicSet": "/devices/(1)/controls/Relay/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MSW.json
+++ b/mqtt/WB-MSW.json
@@ -1,0 +1,278 @@
+{
+  "name": "Универсальный датчик",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MSW",
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicSearch": "/devices/(wb-msw_[0-9]{1,3})/controls/Temperature/meta/type",
+            "topicGet": "/devices/(1)/controls/Temperature",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "HumiditySensor",
+      "characteristics": [
+        {
+          "type": "CurrentRelativeHumidity",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Humidity",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "AirQualitySensor",
+      "logics": [
+        {
+          "type": "AirQualityFromVOCDensity"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "VOCDensity",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Air Quality (VOC)",
+            "minStep": 10,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "CarbonDioxideSensor",
+      "logics": [
+        {
+          "type": "CarbonDioxideDetectedFromCarbonDioxideLevel"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "CarbonDioxideLevel",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/CO2",
+            "minStep": 10,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "LightSensor",
+      "characteristics": [
+        {
+          "type": "CurrentAmbientLightLevel",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Illuminance",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "MotionSensor",
+      "logics": [
+        {
+          "type": "MotionDetectedFromCurrentMotionLevel"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "MotionDetected",
+          "data": {
+            "SwitchOffDelay": 180
+          }
+        },
+        {
+          "type": "C_CurrentMotionLevel",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Current Motion",
+            "minStep": 10,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Buzzer",
+            "topicSet": "/devices/(1)/controls/Buzzer/on"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Red LED",
+            "topicSet": "/devices/(1)/controls/Red LED/on"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Green LED",
+            "topicSet": "/devices/(1)/controls/Green LED/on"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 1",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM1",
+            "topicSet": "/devices/(1)/controls/Play from ROM1/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 2",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM2",
+            "topicSet": "/devices/(1)/controls/Play from ROM2/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 3",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM3",
+            "topicSet": "/devices/(1)/controls/Play from ROM3/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 4",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM4",
+            "topicSet": "/devices/(1)/controls/Play from ROM4/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 5",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM5",
+            "topicSet": "/devices/(1)/controls/Play from ROM5/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 6",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM6",
+            "topicSet": "/devices/(1)/controls/Play from ROM6/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Отправить ИК 7",
+      "visible": false,
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Play from ROM7",
+            "topicSet": "/devices/(1)/controls/Play from ROM7/on"
+          },
+          "data": {
+            "SwitchOffTime": 0.1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WB-MS_2.json
+++ b/mqtt/WB-MS_2.json
@@ -1,0 +1,100 @@
+{
+  "name": "Комбинированный датчик",
+  "manufacturer": "WirenBoard",
+  "model": "WB-MS v.2",
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicSearch": "/devices/(wb-ms_[0-9]{1,3})/controls/Temperature/meta/type",
+            "topicGet": "/devices/(1)/controls/Temperature",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "HumiditySensor",
+      "characteristics": [
+        {
+          "type": "CurrentRelativeHumidity",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Humidity",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "LightSensor",
+      "characteristics": [
+        {
+          "type": "CurrentAmbientLightLevel",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/Illuminance",
+            "minStep": 5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "AirQualitySensor",
+      "logics": [
+        {
+          "type": "AirQualityFromVOCDensity"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "VOCDensity",
+          "link": {
+            "type": "Integer",
+            "topicGet": "/devices/(1)/controls/Air Quality (VOC)",
+            "minStep": 10,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "visible": false,
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/External Sensor 1",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    },
+    {
+      "visible": false,
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": {
+            "type": "Double",
+            "topicGet": "/devices/(1)/controls/External Sensor 2",
+            "minStep": 0.5,
+            "checkValue": true
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/mqtt/WBE2-DO-R6C-1.json
+++ b/mqtt/WBE2-DO-R6C-1.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBE2-DO-R6C-1",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(MOD[1-9]_OUT[1-9])/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-AI-DV-12.json
+++ b/mqtt/WBIO-AI-DV-12.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-AI-DV-12/4-20mA",
+  "visible": false,
+  "services": [
+    {
+      "type": "C_VoltMeter",
+      "characteristics": [
+        {
+          "type": "C_Volt",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-adc)/controls/(EXT[0-9]_A[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-AO-10V-8.json
+++ b/mqtt/WBIO-AO-10V-8.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-AO-10V-8",
+  "services": [
+    {
+      "type": "Lightbulb",
+      "characteristics": [
+        {
+          "type": "Brightness",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-dac)/controls/(EXT[0-9]_O[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on",
+            "maxValue": 10000
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-DI-DR.json
+++ b/mqtt/WBIO-DI-DR.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DI-DR",
+  "services": [
+    {
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_DR[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-DI-IN.json
+++ b/mqtt/WBIO-DI-IN.json
@@ -1,0 +1,22 @@
+{
+  "name": "Напряжение",
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DI-IN",
+  "services": [
+    {
+      "name": "Напряжение",
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_IN[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-DO-HS-8.json
+++ b/mqtt/WBIO-DO-HS-8.json
@@ -1,0 +1,21 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DO-HS-8",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_HS[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/mqtt/WBIO-DO-R10A-8.json
+++ b/mqtt/WBIO-DO-R10A-8.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DO-R10A-8",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_R3A[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-DO-R10R-4.json
+++ b/mqtt/WBIO-DO-R10R-4.json
@@ -1,0 +1,32 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DO-R10R-4",
+  "services": [
+    {
+      "type": "WindowCovering",
+      "logics": [
+        {
+          "type": "TimerBasedPositionState",
+          "options": {
+            "WarmingUpTime": "1000",
+            "MovingTime": "15000"
+          }
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "C_TargetPositionState",
+          "link": {
+            "type": "Integer",
+            "format": "WBCovering",
+            "events": false,
+            "write": true,
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_DIR[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/WBIO-DO-R1G-16.json
+++ b/mqtt/WBIO-DO-R1G-16.json
@@ -1,0 +1,20 @@
+{
+  "manufacturer": "WirenBoard",
+  "model": "WBIO-DO-R1G/SSR",
+  "services": [
+    {
+      "type": "Switch",
+      "characteristics": [
+        {
+          "type": "On",
+          "link": {
+            "type": "Integer",
+            "topicSearch": "/devices/(wb-gpio)/controls/(EXT[0-9]_K[0-9]{1,2})/meta/type",
+            "topicGet": "/devices/(1)/controls/(2)",
+            "topicSet": "/devices/(1)/controls/(2)/on"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mqtt/Wb-gpio.json
+++ b/mqtt/Wb-gpio.json
@@ -1,0 +1,84 @@
+[
+  {
+    "manufacturer": "WirenBoard",
+    "model": "I2C",
+    "visible": false,
+    "services": [
+      {
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-gpio)/controls/(A[0-9]_OUT)/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "topicSet": "/devices/(1)/controls/(2)/on"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "I2C",
+    "visible": false,
+    "services": [
+      {
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-gpio)/controls/(W[0-9]_OUT)/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "topicSet": "/devices/(1)/controls/(2)/on"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "I2C",
+    "visible": false,
+    "services": [
+      {
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-gpio)/controls/(A[0-9]_IN)/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "I2C",
+    "visible": false,
+    "services": [
+      {
+        "type": "ContactSensor",
+        "characteristics": [
+          {
+            "type": "ContactSensorState",
+            "link": {
+              "type": "Integer",
+              "topicSearch": "/devices/(wb-gpio)/controls/(W[0-9]_IN)/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Добавить шаблоны, которые есть в текущей бета версии Спрутхаба - beta 1.10.2(12979) Шаблоны (4604).