### PR TITLE
Feature/int 159 update templates for spruthub

### DIFF
--- a/mqtt/WB-LED.json
+++ b/mqtt/WB-LED.json
@@ -3,6 +3,7 @@
     "manufacturer": "Wiren Board",
     "model": "WB-LED",
     "name": "Цветная лента",
+    "catalogId": 3979,
     "services": [
       {
         "type": "Lightbulb",
@@ -142,7 +143,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Counter"
             }
           }
@@ -156,7 +157,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
             }
           }
@@ -170,7 +171,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
             }
           }
@@ -184,7 +185,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
             }
           }
@@ -198,7 +199,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
             }
           }

--- a/mqtt/WB-M1W2.json
+++ b/mqtt/WB-M1W2.json
@@ -3,6 +3,7 @@
     "name": "Датчик температуры",
     "manufacturer": "Wiren Board",
     "model": "WB-M1W2",
+    "catalogId": 72,
     "services": [
       {
         "type": "TemperatureSensor",
@@ -10,7 +11,7 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-m1w2_[0-9]{1,3})/controls/External Sensor ([0-9])/meta/type",
               "topicGet": "/devices/(1)/controls/External Sensor (2)",
               "minStep": 0.5,
@@ -42,15 +43,14 @@
     "services": [
       {
         "name": "Состояние входа",
-        "visible": false,
         "type": "ContactSensor",
         "characteristics": [
           {
             "type": "ContactSensorState",
             "link": {
               "type": "Integer",
-              "topicSearch": "/devices/(wb-m1w2_[0-9]{1,3})/controls/Discrete Input ([0-9])/meta/type",
-              "topicGet": "/devices/(1)/controls/Discrete Input (2)"
+              "topicSearch": "/devices/(wb-m1w2_[0-9]{1,3})/controls/(Input [0-9])/meta/type",
+              "topicGet": "/devices/(1)/controls/(2)"
             }
           }
         ]
@@ -63,8 +63,8 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
-              "topicGet": "/devices/(1)/controls/Counter (2)"
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/(2) counter"
             }
           }
         ]

--- a/mqtt/WB-MAI6.json
+++ b/mqtt/WB-MAI6.json
@@ -42,5 +42,49 @@
         ]
       }
     ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "WB-MAI6",
+    "catalogId": 4000,
+    "services": [
+      {
+        "name": "Амперметр",
+        "type": "C_AmpereMeter",
+        "characteristics": [
+          {
+            "type": "C_Ampere",
+            "link": {
+              "type": "Double",
+              "topicSearch": "/devices/(wb-mai6_[0-9]{1,3})/controls/(IN [0-9]{1,2}.?[PN]* Current)/meta",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "scale": 0.001
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "manufacturer": "WirenBoard",
+    "model": "WB-MAI6",
+    "catalogId": 4000,
+    "services": [
+      {
+        "name": "Дистанция",
+        "type": "C_DistanceSensor",
+        "characteristics": [
+          {
+            "type": "C_Distance",
+            "link": {
+              "type": "Double",
+              "topicSearch": "/devices/(wb-mai6_[0-9]{1,3})/controls/(IN [0-9]{1,2}.?[PN]* Value)/meta",
+              "topicGet": "/devices/(1)/controls/(2)",
+              "scale": 0.01
+            }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/mqtt/WB-MAO4.json
+++ b/mqtt/WB-MAO4.json
@@ -2,7 +2,8 @@
   {
     "manufacturer": "Wiren Board",
     "model": "WB-MAO4",
-    "name": "Выход 0-10 В",
+    "name": "Выход 0-10 В и дискретный вход",
+    "catalogId": 70,
     "services": [
       {
         "type": "Lightbulb",
@@ -80,7 +81,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Counter"
             }
           }
@@ -94,7 +95,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Short Press Counter"
             }
           }
@@ -108,7 +109,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
             }
           }
@@ -122,7 +123,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
             }
           }
@@ -136,7 +137,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Short Long Press Counter"
             }
           }

--- a/mqtt/WB-MAP12E-fw2.json
+++ b/mqtt/WB-MAP12E-fw2.json
@@ -3,6 +3,7 @@
     "name": "Параметры электросети",
     "manufacturer": "Wiren Board",
     "model": "WB-MAP12E fw2",
+    "catalogId": 3208,
     "services": [
       {
         "name": "Irms",
@@ -12,7 +13,7 @@
           {
             "type": "C_Ampere",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map12e_[0-9]{1,3})/controls/Ch ([0-9]{1,2}) Irms L([0-9]{1,2})/meta/type",
               "topicGet": "/devices/(1)/controls/Ch (2) Irms L(3)"
             }
@@ -27,7 +28,7 @@
           {
             "type": "C_Ampere",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch (2) Ipeak L(3)"
             }
           }
@@ -41,7 +42,7 @@
           {
             "type": "C_Watt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch (2) P L(3)"
             }
           }
@@ -50,12 +51,12 @@
       {
         "name": "Энергия AP",
         "visible": true,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch (2) AP energy L(3)"
             }
           }
@@ -71,12 +72,12 @@
       {
         "name": "Общая энергия AP Ch 1",
         "visible": false,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map12e_[0-9]{1,3})/controls/Ch 1 Total AP energy/meta/type",
               "topicGet": "/devices/(1)/controls/Ch 1 Total AP energy"
             }
@@ -86,12 +87,12 @@
       {
         "name": "Общая энергия AP Ch 2",
         "visible": false,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch 2 Total AP energy"
             }
           }
@@ -100,12 +101,12 @@
       {
         "name": "Общая энергия AP Ch 3",
         "visible": false,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch 3 Total AP energy"
             }
           }
@@ -114,12 +115,12 @@
       {
         "name": "Общая энергия AP Ch 4",
         "visible": false,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ch 4 Total AP energy"
             }
           }
@@ -133,7 +134,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Urms L1"
             }
           }
@@ -147,7 +148,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Upeak L1"
             }
           }
@@ -161,7 +162,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Urms L2"
             }
           }
@@ -175,7 +176,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Upeak L2"
             }
           }
@@ -189,7 +190,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Urms L3"
             }
           }
@@ -203,7 +204,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Upeak L3"
             }
           }

--- a/mqtt/WB-MAP3E-fw2.json
+++ b/mqtt/WB-MAP3E-fw2.json
@@ -3,6 +3,7 @@
     "name": "Параметры электросети",
     "manufacturer": "Wiren Board",
     "model": "WB-MAP3E fw2",
+    "catalogId": 3209,
     "services": [
       {
         "name": "Urms",
@@ -12,7 +13,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map3(?:e_|et_)[0-9]{1,3})/controls/Urms L([0-9]{1,2})/meta/type",
               "topicGet": "/devices/(1)/controls/Urms L(2)"
             }
@@ -27,7 +28,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Upeak L(2)"
             }
           }
@@ -41,7 +42,7 @@
           {
             "type": "C_Ampere",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Irms L(2)"
             }
           }
@@ -55,7 +56,7 @@
           {
             "type": "C_Ampere",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Ipeak L(2)"
             }
           }
@@ -69,7 +70,7 @@
           {
             "type": "C_Watt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/P L(2)"
             }
           }
@@ -78,12 +79,12 @@
       {
         "name": "Энергия AP",
         "visible": true,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/AP energy L(2)"
             }
           }
@@ -104,7 +105,7 @@
           {
             "type": "C_Watt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map3(?:e_|et_)[0-9]{1,3})/controls/(Total P)/meta/type",
               "topicGet": "/devices/(1)/controls/(2)"
             }
@@ -114,12 +115,12 @@
       {
         "name": "Энергия AP",
         "visible": false,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Total AP energy"
             }
           }

--- a/mqtt/WB-MAP3EV.json
+++ b/mqtt/WB-MAP3EV.json
@@ -3,6 +3,7 @@
     "name": "Параметры электросети",
     "manufacturer": "Wiren Board",
     "model": "WB-MAP3EV",
+    "catalogId": 3940,
     "services": [
       {
         "name": "Urms",
@@ -12,7 +13,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map3ev_[0-9]{1,3})/controls/Urms L([0-9]{1,2})/meta/type",
               "topicGet": "/devices/(1)/controls/Urms L(2)"
             }
@@ -27,7 +28,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Upeak L(2)"
             }
           }

--- a/mqtt/WB-MAP6S.json
+++ b/mqtt/WB-MAP6S.json
@@ -3,6 +3,7 @@
     "name": "Параметры электросети",
     "manufacturer": "Wiren Board",
     "model": "WB-MAP6S fw2",
+    "catalogId": 1646,
     "services": [
       {
         "name": "Irms",
@@ -12,7 +13,7 @@
           {
             "type": "C_Ampere",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map6s_[0-9]{1,3})/controls/Irms ([0-9]{1,2})/meta/type",
               "topicGet": "/devices/(1)/controls/Irms (2)"
             }
@@ -27,7 +28,7 @@
           {
             "type": "C_Watt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/P (2)"
             }
           }
@@ -36,12 +37,12 @@
       {
         "name": "Энергия AP",
         "visible": true,
-        "type": "C_KilowattHourMeter",
+        "type": "C_KiloWattHourMeter",
         "characteristics": [
           {
-            "type": "C_KilowattHour",
+            "type": "C_KiloWattHour",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/AP energy (2)"
             }
           }
@@ -62,7 +63,7 @@
           {
             "type": "C_Volt",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-map6s_[0-9]{1,3})/controls/(Urms)/meta/type",
               "topicGet": "/devices/(1)/controls/(2)"
             }

--- a/mqtt/WB-MCM8.json
+++ b/mqtt/WB-MCM8.json
@@ -2,6 +2,7 @@
   "manufacturer": "Wiren Board",
   "model": "WB-MCM8",
   "name": "Дискретный вход",
+  "catalogId": 1765,
   "services": [
     {
       "name": "Состояние входа",
@@ -26,7 +27,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) counter"
           }
         }
@@ -40,7 +41,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
           }
         }
@@ -54,7 +55,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
           }
         }
@@ -68,7 +69,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
           }
         }
@@ -82,7 +83,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
           }
         }

--- a/mqtt/WB-MDM3.json
+++ b/mqtt/WB-MDM3.json
@@ -2,7 +2,7 @@
   {
     "manufacturer": "Wiren Board",
     "model": "WB-MDM3",
-    "name": "Канал диммера",
+    "name": "Канал диммера и дискретный вход",
     "catalogId": 68,
     "services": [
       {

--- a/mqtt/WB-MIR.json
+++ b/mqtt/WB-MIR.json
@@ -3,6 +3,7 @@
     "name": "Датчик температуры",
     "manufacturer": "Wiren Board",
     "model": "WB-MIR v.2",
+    "catalogId": 3213,
     "services": [
       {
         "type": "TemperatureSensor",
@@ -11,7 +12,7 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-mir_v2_[0-9]{1,3})/controls/External Temperature Sensor/meta/type",
               "topicGet": "/devices/(1)/controls/External Temperature Sensor",
               "minStep": 0.5,
@@ -55,7 +56,7 @@
               "topicSet": "/devices/(1)/controls/Play from ROM(2)/on"
             },
             "data": {
-              "SwitchOffTime": 100
+              "SwitchOffTime": 0.1
             }
           }
         ]

--- a/mqtt/WB-MODx_IN.json
+++ b/mqtt/WB-MODx_IN.json
@@ -3,6 +3,7 @@
     "name": "Дискретный вход",
     "manufacturer": "Wiren Board",
     "model": "WB-MOD Input",
+    "catalogId": 4393,
     "services": [
       {
         "name": "Состояние входа",

--- a/mqtt/WB-MODx_K.json
+++ b/mqtt/WB-MODx_K.json
@@ -3,6 +3,7 @@
     "name": "Дискретный выход",
     "manufacturer": "Wiren Board",
     "model": "WB-MOD Relay",
+    "catalogId": 4392,
     "services": [
       {
         "name": "Реле",

--- a/mqtt/WB-MR6C-NC.json
+++ b/mqtt/WB-MR6C-NC.json
@@ -3,6 +3,7 @@
     "manufacturer": "Wiren Board",
     "model": "WB-MR6C-NC",
     "name": "Канал реле и дискретный вход",
+    "catalogId": 3206,
     "services": [
       {
         "name": "Реле",
@@ -41,7 +42,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) counter"
             }
           }
@@ -55,7 +56,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
             }
           }
@@ -69,7 +70,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
             }
           }
@@ -83,7 +84,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
             }
           }
@@ -97,7 +98,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
             }
           }
@@ -133,7 +134,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) counter"
             }
           }
@@ -147,7 +148,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Single Press Counter"
             }
           }
@@ -161,7 +162,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Long Press Counter"
             }
           }
@@ -175,7 +176,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Double Press Counter"
             }
           }
@@ -189,7 +190,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/(2) Shortlong Press Counter"
             }
           }

--- a/mqtt/WB-MR6CU.json
+++ b/mqtt/WB-MR6CU.json
@@ -1,7 +1,7 @@
 [
   {
     "manufacturer": "Wiren Board",
-    "model": "WB-MR3",
+    "model": "MR6CU",
     "name": "Штора",
     "catalogId": 3207,
     "services": [

--- a/mqtt/WB-MRGBW-D-fw3.json
+++ b/mqtt/WB-MRGBW-D-fw3.json
@@ -3,6 +3,7 @@
     "manufacturer": "Wiren Board",
     "model": "WB-MRGBW-D-fw3",
     "name": "Цветная лента",
+    "catalogId": 69,
     "services": [
       {
         "type": "Lightbulb",
@@ -142,7 +143,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Counter"
             }
           }
@@ -156,7 +157,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
             }
           }
@@ -170,7 +171,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
             }
           }
@@ -184,7 +185,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
             }
           }
@@ -198,7 +199,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
             }
           }

--- a/mqtt/WB-MRWM2.json
+++ b/mqtt/WB-MRWM2.json
@@ -2,6 +2,7 @@
   "manufacturer": "Wiren Board",
   "model": "WB-MRWM2",
   "name": "Канал реле и дискретный вход",
+  "catalogId": 3935,
   "services": [
     {
       "name": "Реле",
@@ -40,7 +41,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) counter"
           }
         }
@@ -54,7 +55,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Single Press Counter"
           }
         }
@@ -68,7 +69,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Long Press Counter"
           }
         }
@@ -82,7 +83,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Double Press Counter"
           }
         }
@@ -96,7 +97,7 @@
         {
           "type": "C_PulseCount",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Input (2) Shortlong Press Counter"
           }
         }
@@ -109,7 +110,7 @@
         {
           "type": "C_Watt",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/P L(2)"
           }
         }
@@ -122,7 +123,7 @@
         {
           "type": "C_Volt",
           "link": {
-            "type": "float",
+            "type": "Double",
             "topicGet": "/devices/(1)/controls/Urms L(2)"
           }
         }
@@ -131,10 +132,10 @@
     {
       "name": "Энергия AP",
       "visible": true,
-      "type": "C_KilowattHourMeter",
+      "type": "C_KiloWattHourMeter",
       "characteristics": [
         {
-          "type": "C_KilowattHour",
+          "type": "C_KiloWattHour",
           "link": {
             "topicGet": "/devices/(1)/controls/AP energy L(2)"
           }

--- a/mqtt/WB-MS2.json
+++ b/mqtt/WB-MS2.json
@@ -3,6 +3,7 @@
     "name": "Комбинированный датчик",
     "manufacturer": "Wiren Board",
     "model": "WB-MS v.2",
+    "catalogId": 74,
     "services": [
       {
         "type": "TemperatureSensor",
@@ -10,7 +11,7 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-ms_[0-9]{1,3})/controls/Temperature/meta/type",
               "topicGet": "/devices/(1)/controls/Temperature",
               "minStep": 0.5,
@@ -25,7 +26,7 @@
           {
             "type": "CurrentRelativeHumidity",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Humidity",
               "minStep": 5,
               "checkValue": true
@@ -39,7 +40,7 @@
           {
             "type": "CurrentAmbientLightLevel",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Illuminance",
               "minStep": 5,
               "checkValue": true
@@ -79,7 +80,7 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-ms_[0-9]{1,3})/controls/External Sensor ([0-9])/meta/type",
               "topicGet": "/devices/(1)/controls/External Sensor (2)",
               "minStep": 0.5,
@@ -118,7 +119,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Input (2) Counter"
             }
           }

--- a/mqtt/WB-MSW3.json
+++ b/mqtt/WB-MSW3.json
@@ -3,6 +3,7 @@
     "name": "Универсальный датчик",
     "manufacturer": "Wiren Board",
     "model": "WB-MSW3",
+    "catalogId": 71,
     "services": [
       {
         "type": "TemperatureSensor",
@@ -10,10 +11,10 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-msw-v3_[0-9]{1,3})/controls/Temperature/meta/type",
               "topicGet": "/devices/(1)/controls/Temperature",
-              "minStep": 0.5,
+              "minStep": 0.1,
               "checkValue": true
             }
           }
@@ -25,9 +26,9 @@
           {
             "type": "CurrentRelativeHumidity",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Humidity",
-              "minStep": 5,
+              "minStep": 1,
               "checkValue": true
             }
           }
@@ -77,9 +78,9 @@
           {
             "type": "CurrentAmbientLightLevel",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Illuminance",
-              "minStep": 5,
+              "minStep": 1,
               "checkValue": true
             }
           }
@@ -96,7 +97,7 @@
           {
             "type": "C_CurrentNoiseLevel",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Sound Level",
               "minStep": 5,
               "checkValue": true
@@ -115,7 +116,7 @@
           {
             "type": "MotionDetected",
             "data": {
-              "SwitchOffDelay": 180000
+              "SwitchOffDelay": 180
             }
           },
           {
@@ -192,7 +193,7 @@
               "topicSet": "/devices/(1)/controls/Play from ROM(2)/on"
             },
             "data": {
-              "SwitchOffTime": 100
+              "SwitchOffTime": 0.1
             }
           }
         ]

--- a/mqtt/WB-MSW4.json
+++ b/mqtt/WB-MSW4.json
@@ -3,6 +3,7 @@
     "name": "Универсальный датчик",
     "manufacturer": "Wiren Board",
     "model": "WB-MSW4",
+    "catalogId": 4317,
     "services": [
       {
         "type": "TemperatureSensor",
@@ -10,10 +11,10 @@
           {
             "type": "CurrentTemperature",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-msw-v4_[0-9]{1,3})/controls/Temperature/meta/type",
               "topicGet": "/devices/(1)/controls/Temperature",
-              "minStep": 0.5,
+              "minStep": 0.1,
               "checkValue": true
             }
           }
@@ -25,9 +26,9 @@
           {
             "type": "CurrentRelativeHumidity",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Humidity",
-              "minStep": 5,
+              "minStep": 1,
               "checkValue": true
             }
           }
@@ -77,9 +78,9 @@
           {
             "type": "CurrentAmbientLightLevel",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Illuminance",
-              "minStep": 5,
+              "minStep": 1,
               "checkValue": true
             }
           }
@@ -96,7 +97,7 @@
           {
             "type": "C_CurrentNoiseLevel",
             "link": {
-              "type": "Float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/Sound Level",
               "minStep": 5,
               "checkValue": true
@@ -115,7 +116,7 @@
           {
             "type": "MotionDetected",
             "data": {
-              "SwitchOffDelay": 180000
+              "SwitchOffDelay": 180
             }
           },
           {
@@ -192,7 +193,7 @@
               "topicSet": "/devices/(1)/controls/Play from ROM(2)/on"
             },
             "data": {
-              "SwitchOffTime": 100
+              "SwitchOffTime": 0.1
             }
           }
         ]

--- a/mqtt/WB-MWAC.json
+++ b/mqtt/WB-MWAC.json
@@ -3,6 +3,7 @@
     "name": "Защита от протечки",
     "manufacturer": "Wiren Board",
     "model": "WB-MWAC",
+    "catalogId": 381,
     "services": [
       {
         "name": "Кран 1",
@@ -48,6 +49,20 @@
         ]
       },
       {
+        "name": "Режим: влажная уборка",
+        "type": "Switch",
+        "characteristics": [
+          {
+            "type": "On",
+            "link": {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Cleaning Mode",
+              "topicSet": "/devices/(1)/controls/Cleaning Mode/on"
+            }
+          }
+        ]
+      },
+      {
         "name": "Счётчик 1",
         "visible": false,
         "type": "C_PulseMeter",
@@ -55,7 +70,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-mwac_[0-9]{1,3})/controls/P1 Counter/meta/type",
               "topicGet": "/devices/(1)/controls/P1 Counter"
             }
@@ -70,7 +85,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicSearch": "/devices/(wb-mwac_[0-9]{1,3})/controls/P2 Counter/meta/type",
               "topicGet": "/devices/(1)/controls/P2 Counter"
             }
@@ -105,7 +120,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/F(2) Counter"
             }
           }
@@ -133,7 +148,7 @@
           {
             "type": "C_PulseCount",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/S(2) Counter"
             }
           }

--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -70,7 +70,7 @@
           {
             "type": "C_CubicMeter",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/P1 Volume"
             }
           }
@@ -84,7 +84,7 @@
           {
             "type": "C_CubicMeter",
             "link": {
-              "type": "float",
+              "type": "Double",
               "topicGet": "/devices/(1)/controls/P2 Volume"
             }
           }


### PR DESCRIPTION
Обновлены шаблоны в соответствии с тем, что сейчас актуальны в Spruthub beta 1.10.2(12979) Шаблоны (4604).
WB-MRM2-mini - оставлен корректный с режимом штор.
WB-MRM2-mini-NC - оставлен корректный от 19.12.23г.