### PR TITLE
Feature/int 786 add ebus and opentherm template

### DIFF
--- a/mqtt/WBE2-I-EBUS.json
+++ b/mqtt/WBE2-I-EBUS.json
@@ -43,7 +43,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -100,8 +100,8 @@
           "type": "CurrentHeatingCoolingState",
           "link": [
             {
-              "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -153,7 +153,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -202,7 +202,7 @@
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)"
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
             }
           ]
         }

--- a/mqtt/WBE2-I-EBUS.json
+++ b/mqtt/WBE2-I-EBUS.json
@@ -175,24 +175,6 @@
       ]
     },
     {
-      "name": "Давление в котле",
-      "type": "C_AtmosphericPressureSensor",
-      "characteristics": [
-        {
-          "type": "C_CurrentAtmosphericPressure",
-          "link": [
-            {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/Water Pressure"
-            }
-          ],
-          "maxValue": 6,
-          "minStep": 0.01,
-          "unit": "бар"
-        }
-      ]
-    },
-    {
       "name": "Модуляция горелки",
       "visible": false,
       "type": "C_Option",
@@ -205,6 +187,23 @@
               "topicGet": "/devices/(1)/controls/Burner Modulation Level"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "Давление воды",
+      "type": "C_Option",
+      "characteristics": [
+        {
+          "type": "C_Double",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Water Pressure"
+            }
+          ],
+          "minStep": 0.1,
+          "unit": "Бар"
         }
       ]
     }

--- a/mqtt/WBE2-I-EBUS.json
+++ b/mqtt/WBE2-I-EBUS.json
@@ -1,7 +1,7 @@
 {
-    "name": "WBE2-I-EBUS",
-    "manufacturer": "Wiren Board",
-    "model": "WBE2-I-EBUS",
+  "name": "WBE2-I-EBUS",
+  "manufacturer": "Wiren Board",
+  "model": "WBE2-I-EBUS",
   "modelIds": [
     "/devices/(wbe2-i-ebus_[0-9]{1,3})/controls/.*/meta"
   ],
@@ -35,15 +35,15 @@
             }
           ],
           "minValue": 0,
-          "maxValue": 80,
-          "minStep": 1.0
+          "maxValue": 85,
+          "minStep": 1
         },
         {
           "type": "CurrentHeatingCoolingState",
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -94,14 +94,14 @@
           ],
           "minValue": 0,
           "maxValue": 35,
-          "minStep": 1.0
+          "minStep": 1
         },
         {
           "type": "CurrentHeatingCoolingState",
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -145,15 +145,15 @@
             }
           ],
           "minValue": 0,
-          "maxValue": 80,
-          "minStep": 1.0
+          "maxValue": 85,
+          "minStep": 1
         },
         {
           "type": "CurrentHeatingCoolingState",
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -202,7 +202,7 @@
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)"
             }
           ]
         }

--- a/mqtt/WBE2-I-EBUS.json
+++ b/mqtt/WBE2-I-EBUS.json
@@ -1,0 +1,247 @@
+{
+    "name": "WBE2-I-EBUS",
+    "manufacturer": "Wiren Board",
+    "model": "WBE2-I-EBUS",
+  "modelIds": [
+    "/devices/(wbe2-i-ebus_[0-9]{1,3})/controls/.*/meta"
+  ],
+  "catalogId": 3538,
+  "services": [
+    {
+      "name": "Отопление",
+      "type": "Thermostat",
+      "logics": [
+        {
+          "type": "CurrentHeatingCoolingFromTarget"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Heating Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Heating Setpoint",
+              "topicSet": "/devices/(1)/controls/Heating Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 80,
+          "minStep": 1.0
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Комнатная температура",
+      "visible": false,
+      "type": "Thermostat",
+      "logics": [
+        {
+          "type": "CurrentHeatingCoolingFromTarget"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Room Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Room Temperature Setpoint",
+              "topicSet": "/devices/(1)/controls/Room Temperature Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 35,
+          "minStep": 1.0
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Горячее водоснабжение",
+      "type": "Thermostat",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Hot Water Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Hot Water Setpoint",
+              "topicSet": "/devices/(1)/controls/Hot Water Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 80,
+          "minStep": 1.0
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Давление в котле",
+      "type": "C_AtmosphericPressureSensor",
+      "characteristics": [
+        {
+          "type": "C_CurrentAtmosphericPressure",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Water Pressure"
+            }
+          ],
+          "maxValue": 6,
+          "minStep": 0.01,
+          "unit": "бар"
+        }
+      ]
+    },
+    {
+      "name": "Модуляция горелки",
+      "visible": false,
+      "type": "C_Option",
+      "characteristics": [
+        {
+          "type": "C_Intensity",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "options": [
+    {
+      "name": "Ошибка связи с котлом",
+      "type": "Boolean",
+      "link": [
+        {
+          "type": "Boolean",
+          "topicGet": "/devices/(1)/controls/Invalid Connection"
+        }
+      ],
+      "inputType": "STATUS"
+    },
+    {
+      "name": "Версия FW модуля",
+      "type": "String",
+      "link": [
+        {
+          "type": "Double",
+          "topicGet": "/devices/(1)/controls/FW Version"
+        }
+      ],
+      "inputType": "STATUS"
+    },
+    {
+      "name": "Код ошибки",
+      "type": "String",
+      "link": [
+        {
+          "type": "Double",
+          "topicGet": "/devices/(1)/controls/Error Code"
+        }
+      ],
+      "inputType": "STATUS"
+    }
+  ]
+}

--- a/mqtt/WBE2-I-OPENTHERM.json
+++ b/mqtt/WBE2-I-OPENTHERM.json
@@ -1,0 +1,247 @@
+{
+  "name": "WBE2-I-EBUS",
+  "manufacturer": "Wiren Board",
+  "model": "WBE2-I-EBUS",
+  "modelIds": [
+    "/devices/(wbe2-i-ebus_[0-9]{1,3})/controls/.*/meta"
+  ],
+  "catalogId": 3538,
+  "services": [
+    {
+      "name": "Отопление",
+      "type": "Thermostat",
+      "logics": [
+        {
+          "type": "CurrentHeatingCoolingFromTarget"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Heating Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Heating Setpoint",
+              "topicSet": "/devices/(1)/controls/Heating Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 80,
+          "minStep": 1
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Комнатная температура",
+      "visible": false,
+      "type": "Thermostat",
+      "logics": [
+        {
+          "type": "CurrentHeatingCoolingFromTarget"
+        }
+      ],
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Room Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Room Temperature Setpoint",
+              "topicSet": "/devices/(1)/controls/Room Temperature Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 35,
+          "minStep": 1
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Горячее водоснабжение",
+      "type": "Thermostat",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Hot Water Temperature"
+            }
+          ]
+        },
+        {
+          "type": "TargetTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Hot Water Setpoint",
+              "topicSet": "/devices/(1)/controls/Hot Water Setpoint/on"
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 80,
+          "minStep": 1
+        },
+        {
+          "type": "CurrentHeatingCoolingState",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "map": {
+                "OFF": "0",
+                "HEAT": "1~100"
+              }
+            }
+          ],
+          "validValues": "OFF,HEAT"
+        },
+        {
+          "type": "TargetHeatingCoolingState",
+          "validValues": "HEAT",
+          "option": true
+        },
+        {
+          "type": "TemperatureDisplayUnits",
+          "validValues": "CELSIUS",
+          "option": true
+        }
+      ]
+    },
+    {
+      "name": "Давление в котле",
+      "type": "C_AtmosphericPressureSensor",
+      "characteristics": [
+        {
+          "type": "C_CurrentAtmosphericPressure",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Water Pressure"
+            }
+          ],
+          "maxValue": 6,
+          "minStep": 0.01,
+          "unit": "бар"
+        }
+      ]
+    },
+    {
+      "name": "Модуляция горелки",
+      "visible": false,
+      "type": "C_Option",
+      "characteristics": [
+        {
+          "type": "C_Intensity",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "options": [
+    {
+      "name": "Ошибка связи с котлом",
+      "type": "Boolean",
+      "link": [
+        {
+          "type": "Boolean",
+          "topicGet": "/devices/(1)/controls/Invalid Connection"
+        }
+      ],
+      "inputType": "STATUS"
+    },
+    {
+      "name": "Версия FW модуля",
+      "type": "String",
+      "link": [
+        {
+          "type": "Double",
+          "topicGet": "/devices/(1)/controls/FW Version"
+        }
+      ],
+      "inputType": "STATUS"
+    },
+    {
+      "name": "Код ошибки",
+      "type": "String",
+      "link": [
+        {
+          "type": "Double",
+          "topicGet": "/devices/(1)/controls/Error Code"
+        }
+      ],
+      "inputType": "STATUS"
+    }
+  ]
+}

--- a/mqtt/WBE2-I-OPENTHERM.json
+++ b/mqtt/WBE2-I-OPENTHERM.json
@@ -43,7 +43,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -101,7 +101,7 @@
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -153,7 +153,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -202,7 +202,7 @@
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)"
             }
           ]
         }

--- a/mqtt/WBE2-I-OPENTHERM.json
+++ b/mqtt/WBE2-I-OPENTHERM.json
@@ -1,11 +1,11 @@
 {
-  "name": "WBE2-I-EBUS",
+  "name": "WBE2-I-OPENTHERM",
   "manufacturer": "Wiren Board",
-  "model": "WBE2-I-EBUS",
+  "model": "WBE2-I-OPENTHERM",
   "modelIds": [
-    "/devices/(wbe2-i-ebus_[0-9]{1,3})/controls/.*/meta"
+    "/devices/(wbe2-i-opentherm_[0-9]{1,3})/controls/.*/meta"
   ],
-  "catalogId": 3538,
+  "catalogId": 3539,
   "services": [
     {
       "name": "Отопление",
@@ -43,7 +43,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -100,8 +100,8 @@
           "type": "CurrentHeatingCoolingState",
           "link": [
             {
-              "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -153,7 +153,7 @@
           "link": [
             {
               "type": "Double",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level",
               "map": {
                 "OFF": "0",
                 "HEAT": "1~100"
@@ -201,8 +201,8 @@
           "type": "C_Intensity",
           "link": [
             {
-              "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Burner Modulation Level (%)"
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Burner Modulation Level"
             }
           ]
         }

--- a/mqtt/WBE2-I-OPENTHERM.json
+++ b/mqtt/WBE2-I-OPENTHERM.json
@@ -175,24 +175,6 @@
       ]
     },
     {
-      "name": "Давление в котле",
-      "type": "C_AtmosphericPressureSensor",
-      "characteristics": [
-        {
-          "type": "C_CurrentAtmosphericPressure",
-          "link": [
-            {
-              "type": "Double",
-              "topicGet": "/devices/(1)/controls/Water Pressure"
-            }
-          ],
-          "maxValue": 6,
-          "minStep": 0.01,
-          "unit": "бар"
-        }
-      ]
-    },
-    {
       "name": "Модуляция горелки",
       "visible": false,
       "type": "C_Option",
@@ -205,6 +187,23 @@
               "topicGet": "/devices/(1)/controls/Burner Modulation Level"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "Давление воды",
+      "type": "C_Option",
+      "characteristics": [
+        {
+          "type": "C_Double",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Water Pressure"
+            }
+          ],
+          "minStep": 0.1,
+          "unit": "Бар"
         }
       ]
     }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил шаблоны WBE2-I-EBUS и WBE2-I-OPENTHERM.

___________________________________
**Что поменялось для пользователей:**
В спруте уже был "какой-то" шаблон для опентерма. Я его чуть доработал и сделал аналогичный для ебас. Они по сути аналогичные вот как выглядят в спруте:
<img width="1021" height="291" alt="image" src="https://github.com/user-attachments/assets/4ab70802-f707-4fc7-abf6-e1f7eed0981d" />
<img width="670" height="861" alt="image" src="https://github.com/user-attachments/assets/c7d36c96-995d-459a-8088-ecc22f8da94e" />
<img width="676" height="518" alt="image" src="https://github.com/user-attachments/assets/2be79f81-ae9a-485b-93d3-6eefe377b1f9" />
<img width="683" height="842" alt="image" src="https://github.com/user-attachments/assets/8108f602-0f5e-45db-8e9c-a9d4a2228575" />

Что не нравиться: Давление в котле на карточке имеет единицу мм и подписано "атмосферное давление". Внутри карточки в барах.


___________________________________
**Как проверял/а:**
opentherm на нашей плате-стнде.
ebus создал виртуальное устройство эмулирующее устройство ebus

