### PR TITLE
fix template for MWAC2 ver2

### DIFF
--- a/mqtt/WB-MWACv2.json
+++ b/mqtt/WB-MWACv2.json
@@ -49,6 +49,21 @@
     },
     {
       "name": "Режим: протечка",
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Leakage Mode"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Сброс режима протечка",
       "type": "Switch",
       "characteristics": [
         {
@@ -56,10 +71,13 @@
           "link": [
             {
               "type": "Integer",
-              "topicGet": "/devices/(1)/controls/Leakage Mode",
-              "topicSet": "/devices/(1)/controls/Leakage Mode/on"
+              "topicGet": "/devices/(1)/controls/Leakage Mode Reset",
+              "topicSet": "/devices/(1)/controls/Leakage Mode Reset/on"
             }
-          ]
+          ],
+          "data": {
+            "SwitchOffTime": 0.1
+          }
         }
       ]
     },


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
У нас в шаблонах поменялось поведение протечки, там теперь один канал показывает протечку, второй сбрасывает.

Теперь аналогично в спруте
___________________________________
**Что поменялось для пользователей:**

Было:
<img width="921" height="341" alt="image" src="https://github.com/user-attachments/assets/52f8e839-1fda-4530-89ef-92e45f4d75ad" />

Стало:
<img width="1206" height="326" alt="image" src="https://github.com/user-attachments/assets/e5632505-b00c-431e-8e5c-e266f6117255" />

___________________________________
**Как проверял/а:**

На нашем стенде
