### PR TITLE
feat: add template for M1W2 v3 fw4.35+ INT-987

### DIFF
--- a/mqtt/WB-M1W2v3.json
+++ b/mqtt/WB-M1W2v3.json
@@ -1,0 +1,41 @@
+{
+  "name": "Датчик температуры",
+  "manufacturer": "Wiren Board",
+  "model": "WB-M1W2 v.3 (fw4.35+)",
+  "modelIds": ["/devices/(wb-m1w2_[0-9]{1,3})/controls/bus([12])_temp([1-9][0-9]?)/meta/type"],
+  "catalogId": 72,
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/bus(2)_temp(3)",
+              "minStep": 0.5,
+              "checkValue": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Датчик подключен",
+      "visible": false,
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/bus(2)_sens(3)_ok"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил шаблон `WB-M1W2v3` для модуля WB-M1W2 ревизии v.3 с
прошивкой ≥ 4.35.0. В этой ревизии модуль умеет работать в режиме
MULTIPLE W1 — до 20 датчиков 1-Wire на каждую из двух шин (раньше
шаблон поддерживал только по одному датчику на шину, как в
hardware v.1/v.2).

___________________________________
**Что поменялось для пользователей:**
Старый шаблон `WB-M1W2` (HW v.1/v.2, топики `External Sensor 1/2`)
остаётся как есть и продолжает работать на старом железе.

Новый шаблон `WB-M1W2v3` ловит топики `bus1_temp1..20` /
`bus2_temp1..20` и создаёт по accessory на каждый активный датчик.
Пустые слоты публикуют 0 — `checkValue:true` блокирует такие
значения для HomeKit, но в самом Sprut.Hub UI accessory всё равно
появляются (это поведение совпадает с другими температурными
шаблонами).

Как это выглядит в Sprut.Hub:
<img width="924" height="744" alt="image" src="https://github.com/user-attachments/assets/d4fee4d7-ce25-4f8e-9240-83154df4dd56" />
<img width="1437" height="419" alt="image" src="https://github.com/user-attachments/assets/73baa382-c48c-40ca-9702-3f7ce6408e7a" />
<img width="732" height="522" alt="image" src="https://github.com/user-attachments/assets/964f4474-cc0d-48cb-a590-f592c8a0d46d" />

Вот как это выглядит в Serial:
Версия v3:
<img width="1661" height="745" alt="image" src="https://github.com/user-attachments/assets/36d96d5f-e3a8-4b78-8508-cee10d5fcf50" />
Версия v2.1:
<img width="1648" height="528" alt="image" src="https://github.com/user-attachments/assets/abebfa7c-5c10-41e4-8011-59736137c5f8" />

___________________________________
**Как проверял/а:**
Проверял на тестовом стенде SprutHub

- WB-M1W2 **v.3** fw 4.35.1 (`wb-m1w2_224`, slave 224) — шаблон
  создал 40 accessory (по 20 на каждую шину). На активных каналах
  (temp1..5 на bus1, temp1..4 на bus2) — живые значения 22.9–24.0 °C,
  пустые слоты — 0 (отфильтрованы `checkValue`).
- WB-M1W2 **v.1** fw 4.35.1 (`wb-m1w2_30`, slave 30) — новый
  шаблон корректно проигнорирован (regex `bus([12])_temp(...)` не
  матчит legacy-топики `External Sensor 1/2`), старый шаблон
  продолжает обслуживать устройство.
