### PR TITLE
feat: add template for WB-MIR v3 fw4.35+ INT-995

### DIFF
--- a/mqtt/WB-MIRv3-fw435.json
+++ b/mqtt/WB-MIRv3-fw435.json
@@ -1,9 +1,9 @@
 {
   "name": "Управление техникой по ИК",
   "manufacturer": "Wiren Board",
-  "model": "WB-MIR v.2",
-  "modelId": "/devices/(wb-mir_v2_[0-9]{1,3})/controls/Play from ROM([0-9]{1,2})/meta/type",
-  "catalogId": 3213,
+  "model": "WB-MIR v.3 (fw4.35+)",
+  "modelId": "/devices/(wb-mir_v3_[0-9]{1,3})/controls/Play from ROM([0-9]{1,2})/meta/type",
+  "catalogId": 5747,
   "services": [
     {
       "name": "Отправить ИК",
@@ -27,4 +27,3 @@
     }
   ]
 }
-

--- a/mqtt/WB-MIRv3-fw435.json
+++ b/mqtt/WB-MIRv3-fw435.json
@@ -2,7 +2,9 @@
   "name": "Управление техникой по ИК",
   "manufacturer": "Wiren Board",
   "model": "WB-MIR v.3 (fw4.35+)",
-  "modelId": "/devices/(wb-mir_v3_[0-9]{1,3})/controls/Play from ROM([0-9]{1,2})/meta/type",
+  "modelIds": [
+    "/devices/(wb-mir_v3_[0-9]{1,3})/controls/Play from ROM([0-9]{1,2})/meta/type"
+  ],
   "catalogId": 5747,
   "services": [
     {

--- a/mqtt/WB-MIRv3-fw435_Temperature.json
+++ b/mqtt/WB-MIRv3-fw435_Temperature.json
@@ -1,0 +1,43 @@
+{
+  "name": "Датчик температуры",
+  "manufacturer": "Wiren Board",
+  "model": "WB-MIR v.3 (fw4.35+)",
+  "modelIds": [
+    "/devices/(wb-mir_v3_[0-9]{1,3})/controls/bus(1)_temp([1-9][0-9]?)/meta/type"
+  ],
+  "catalogId": 5747,
+  "services": [
+    {
+      "type": "TemperatureSensor",
+      "characteristics": [
+        {
+          "type": "CurrentTemperature",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/bus(2)_temp(3)",
+              "minStep": 0.5,
+              "checkValue": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Датчик подключен",
+      "visible": false,
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/bus(2)_sens(3)_ok"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил шаблоны для модуля WB-MIR v.3 с прошивкой ≥ 4.35.
В этой версии прошивки модуль умеет работать в режиме MULTIPLE W1
— до 20 датчиков 1-Wire на единственной шине (раньше шаблон
`WB-MIR_Temperature` поддерживал только один внешний датчик через
топик `External Temperature Sensor`).

Заодно проставил `catalogId: 3213` в существующий шаблон
`WB-MIR.json` (v.2, IR-команды) — у парного `WB-MIR_Temperature.json`
этот id уже стоял, теперь оба файла v.2 указывают на одну страницу
каталога Sprut.AI.
Ссылка - https://sprut.ai/catalog/item/wirenboard-ustrojstvo-ik-upravlenia-wb-mir

___________________________________
**Что поменялось для пользователей:**
Старые шаблоны `WB-MIR` / `WB-MIR_Temperature` (regex
`wb-mir_v2_*`, топики `Play from ROM<n>` и
`External Temperature Sensor`) остаются как есть и продолжают
работать на v.2.

Новые шаблоны:
- `WB-MIRv3-fw435.json` — IR-команды для v.3 (regex
  `wb-mir_v3_*` + `Play from ROM<n>`), `catalogId: 5747`.
  Полный аналог v.2-варианта, но под новый id устройства.
- `WB-MIRv3-fw435_Temperature.json` — температурные датчики v.3
  fw 4.35+ (regex `wb-mir_v3_*` + `bus(1)_temp<1..20>`),
  `catalogId: 5747`. Создаёт по accessory на каждый активный
  датчик, со скрытым ContactSensor по `bus1_sens<n>_ok`.
  Пустые слоты публикуют 0 — `checkValue:true` блокирует такие
  значения для HomeKit, но в Sprut.Hub UI accessory всё равно
  появляются (поведение совпадает с уже принятыми шаблонами
  `WB-M1W2v3` и `WB-MS2-fw436`).

На FW < 4.35 топиков `bus1_temp*` в MQTT нет, regex новых
шаблонов не матчится — для старых прошивок ничего не меняется.

Legacy single-sensor топик в новой прошивке остался для обратной
совместимости (`External Sensor 1`), но в режиме MULTIPLE он
дублирует `bus1_temp1`. Отдельный шаблон под него не делал,
чтобы не плодить дубли accessory в Sprut.Hub.

___________________________________
**Как проверял/а:**
Тестов не проводил, шаблоны корректно добавились в SprutHub:
<img width="699" height="629" alt="image" src="https://github.com/user-attachments/assets/f99bd575-470b-4499-986d-459123d66813" />
<img width="704" height="635" alt="image" src="https://github.com/user-attachments/assets/fe602269-8433-4672-a441-166f964f24d2" />

