### PR TITLE
feat: add template for WB-MCM8-HV INT-986

### DIFF
--- a/mqtt/WB-MCM8-HV.json
+++ b/mqtt/WB-MCM8-HV.json
@@ -1,7 +1,9 @@
 {
   "manufacturer": "Wiren Board",
   "model": "WB-MCM8-HV",
-  "modelId": "/devices/(wb-mcm8-hv_[0-9]{1,3})/controls/Input ([0-9]{1,2})/meta/type",
+  "modelIds": [
+    "/devices/(wb-mcm8-hv_[0-9]{1,3})/controls/Input ([0-9]{1,2})/meta/type"
+  ],
   "name": "Дискретный вход",
   "services": [
     {

--- a/mqtt/WB-MCM8-HV.json
+++ b/mqtt/WB-MCM8-HV.json
@@ -1,0 +1,40 @@
+{
+  "manufacturer": "Wiren Board",
+  "model": "WB-MCM8-HV",
+  "modelId": "/devices/(wb-mcm8-hv_[0-9]{1,3})/controls/Input ([0-9]{1,2})/meta/type",
+  "name": "Дискретный вход",
+  "services": [
+    {
+      "name": "Состояние входа",
+      "visible": false,
+      "type": "ContactSensor",
+      "characteristics": [
+        {
+          "type": "ContactSensorState",
+          "link": [
+            {
+              "type": "Integer",
+              "topicGet": "/devices/(1)/controls/Input (2)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Счетчик",
+      "visible": false,
+      "type": "C_PulseMeter",
+      "characteristics": [
+        {
+          "type": "C_PulseCount",
+          "link": [
+            {
+              "type": "Double",
+              "topicGet": "/devices/(1)/controls/Input (2) counter"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил шаблон `WB-MCM8-HV` для нового устройства Wiren Board —
8-канального модуля-детектора наличия сетевого напряжения 230 В.
Раньше шаблона в репозитории не было.

___________________________________
**Что поменялось для пользователей:**
Появляется автоматическое распознавание устройства `wb-mcm8-hv_*`
в Sprut.Hub. На каждый из 8 входов создаётся accessory с двумя
сервисами:
- `ContactSensor` по топику `Input <N>` — состояние входа
  (есть/нет 230 В).
- `C_PulseMeter` по топику `Input <N> counter` — счётчик
  срабатываний.

Шаблон сделан по образцу существующего `WB-MCM8.json`, но без
сервисов для счётчиков нажатий (single/long/double/shortlong) —
у HV-варианта режима press detection нет, соответствующих
топиков в MQTT не публикуется.

`catalogId` не проставлен: страница устройства в каталоге
Sprut.AI не найдена.

___________________________________
**Как проверял/а:**
Тестов не проводил, шаблон корректно добавился в SprutHub:
<img width="710" height="622" alt="image" src="https://github.com/user-attachments/assets/d109618a-3bc3-4d15-a79f-ed4f8cb32364" />
